### PR TITLE
opal: Add a user-focussed document for petitboot plugins

### DIFF
--- a/opal/petitboot-plugin-spec.txt
+++ b/opal/petitboot-plugin-spec.txt
@@ -1,0 +1,197 @@
+Petitboot Plugins
+=================
+
+DRAFT
+
+This specification is for plugins to the Petitboot Bootloader environment.
+
+The petitboot bootloader is part of the OpenPower firmware stack.
+
+This document describes what plugin authors can expect, what is explicitly
+supported and what is explicitly *not* supported.
+
+Authors
+-------
+Initial Specification Draft: Stewart Smith <stewart@linux.vnet.ibm.com>
+Reference implementation of Petitboot Plugin: Jeremy Kerr <jk@ozlabs.org>
+
+Availability
+------------
+The first op-build release to support petitboot plugins is v1.7 (released
+September 2015). Refer to individual firmware vendor's release notes to
+find minimal firmware versions for shipping machines.
+
+Prior versions of OPAL firmware do *not* support petitboot plugins of any
+type.
+
+Goal
+----
+
+To allow vendors to provide various userspace tools and utilities for
+execution within the petitboot environment.
+
+For example: configuration utilities for RAID cards.
+
+Petitboot plugins are not meant to solve all of the possible problems,
+sometimes providing a bootable image may be preferable to a petitboot
+plugin.
+
+Implementation
+--------------
+See petitboot/utils/pb-plugin source for the reference implementation.
+
+File format
+-----------
+
+Petitboot plugins are a gzip compressed cpio archive ending in ".pb-plugin".
+
+Within this archive, there MUST exist a etc/preboot-plugins/pb-plugin.conf
+file (see pb-plugin.conf definition below).
+
+As of petitboot plugin ABI version 1, the etc/preboot-plugins/ directory
+is reserved and MUST NOT contain any files other than pb-plugin.conf
+
+The archive will be extracted and run in a chroot-like environment, so it
+is RECOMMENDED that plugins follow the Filesystem Hierarchy Standard, although
+this is not REQUIRED. The intention is to isolate the plugin from both other
+plugins and the petitboot environment itself.
+
+The following paths MAY exist but the petitboot environment MAY (and indeed,
+in the current implementation WILL) mount filesystems over them:
+- dev
+- sys
+- proc
+- var
+
+The petitboot environment WILL provide a full proc filesystem in /proc
+The petitboot environment WILL provide a full sysfs filesystem in /sys
+The petitboot environment WILL provide a full set of device nodes in /dev
+The petitboot environment WILL share /var outside of the plugin environment
+(possibly including other plugins' chroots).
+The petitboot environment WILL create the mountpoints if nedeed.
+The petitboot environment WILL create/replace the plugin's etc/resolv.conf
+
+See Plugin ABI section.
+See also: http://refspecs.linuxfoundation.org/fhs.shtml
+
+Petitboot plugin location
+-------------------------
+The petitboot environment MAY support discovery of plugins. It will search
+ONLY in the root directory of accessible file systems.
+
+Petitboot plugins MAY be installed from other locations, possibly even over
+the network.
+
+pb-plugin.conf contents
+----------------------
+This file tells petitboot about the plugin.
+
+Within the petitboot plugin, it is found at etc/preboot-plugins/pb-plugin.conf
+
+Within this file, there MUST exist the following key/value pairs with the format
+KEY=VALUE :
+
+PLUGIN_ABI
+PLUGIN_ABI_MIN
+PLUGIN_VENDOR
+PLUGIN_VENDOR_ID
+PLUGIN_NAME
+PLUGIN_ID
+PLUGIN_VERSION
+PLUGIN_DATE
+PLUGIN_EXECUTABLES
+
+Values MAY be quoted. The pb-plugin.conf file is NOT executed shell and must
+not be treated as such.
+
+Example:
+PLUGIN_ABI='1'
+PLUGIN_ABI_MIN='1'
+PLUGIN_VENDOR='OpenPower Foundation'
+PLUGIN_VENDOR_ID='OpenPower'
+PLUGIN_NAME='Hello World Petitboot Plugin Example 1'
+PLUGIN_ID='Hello World'
+PLUGIN_VERSION='1.0'
+PLUGIN_DATE='2015-09-16'
+PLUGIN_EXECUTABLES='/usr/bin/hello-world /usr/bin/other-binary'
+
+In the future, additional variables may be added, but these ones MUST ALWAYS
+exist. This allows any future incompatible change to gracefully fail, telling
+the user about the presence of a plugin that cannot be run.
+
+The following restrictions apply:
+- PLUGIN_ABI and PLUGIN_ABI_MIN must be numeric (0-9+)
+- PLUGIN_ID and PLUGIN_VENDOR_ID should only contain lowercase alphanumerics
+  and hyphens
+- PLUGIN_DATE *MUST* be in the format YYYY-MM-DD
+  The format MM/DD/YY is EXPLICITLY NOT SUPPORTED or encouraged. Anywhere. Ever.
+
+The PLUGIN_NAME and PLUGIN_VENDOR variables MAY contain UTF-8 encoded
+characters, typically to allow plugins implemented in langauges other than
+English. However, there is no guarantee that users will be using a terminal
+emulator that can support non-ASCII characters. Other variables should only
+contain ASCII characters.
+
+PLUGIN_EXECUTABLES is a space-separated list of executables that are made
+available for the user to invoke. Each executable in PLUGIN_EXECUTABLES
+*SHOULD* have a unique filename (excluding the path). Since the petitboot
+environment creates a wrapper script to execute the plugin from the petitboot
+shell environment, installing two plugins with the same executable name WILL
+conflict, with whatever plugin was installed most recently winning.
+
+It is thus RECOMMENDED that you name executables along the lines of
+'openpower-hello-world' rather than just 'hello-world' so as not to conflict
+with a possible 'acme-hello-world'.
+
+Plugin ABI versioning
+---------------------
+
+The Petitboot environment will support a petitboot plugin ABI version.
+Each petitboot plugin has a minimal ABI version it supports running.
+
+If the petitboot plugin's ABI version is GREATER than the petitboot
+environment's, the plugin MUST NOT be run.
+
+A plugin is OK to run if:
+1. the plugin's ABI matches the petitboot environment's ABI, or
+2. the plugin's minimum ABI is lower than or equal to the petitboot
+   enviornement's ABI
+
+Plugin ABI
+----------
+The Petitboot environment provides the following ABI to plugins:
+- Linux kernel ppc64el ABI
+  - with the expectation that executables fail gracefully if certain
+    kernel features are not available.
+  - depending on optional kernel features is NOT RECOMMENDED.
+    For the large part: be sensible. You can expect syscalls as of
+    linux 4.2 to exist.
+    - Some plugins may REQUIRE certain functionality to be enabled in
+      the petitboot kernel (for example: a specific RAID driver).
+      It is encouraged to fail gracefully in the absence of this
+      driver with an easy to understand error message for the user.
+
+It EXPLICITLY DOES NOT support kernel modules. You MUST NOT include
+kernel modules in your plugin. If you require kernel module support,
+ship instead a bootable disk rather than a petitboot plugin.
+
+As each plugin executes in its own chroot environment, binaries must
+either be statically linked or MUST include ALL dependencies (for example:
+dynamic linker, libc, ncurses)
+
+Plugin executables execute as root in the plugin's chroot environment. The
+plugin chroot environment is temporary and IS NOT persistent across reboots.
+This is implemented in the reference implementation by extracting the
+plugin into a ram disk.
+
+The var/ mountpoint inside a plugin chroot environment is a bind mount
+of the petitboot environment /var. Be sensible with logging within your
+petitboot plugin: don't overwrite petitboot logs, log to a file name unique
+to your plugin.
+
+While more than just var/log is exposed to the plugin, it is explictily
+NOT SUPPORTED to use the var/ bind mount for anything BUT logging.
+
+It is possible that in a future release, the implementation may change so
+that the plugin CANNOT access anything but its own logs in var/ but that
+the petitboot environment CAN access the logs of the plugin.

--- a/opal/petitboot-plugins.txt
+++ b/opal/petitboot-plugins.txt
@@ -1,197 +1,160 @@
-Petitboot Plugins
+Petitboot plugins
 =================
 
-DRAFT
+The petitboot plugin infrastructure is a facility for adding binaries to the
+petitboot shell environment. For example, a RAID-hardware vendor can provide
+a plugin that adds their devices' RAID configuration tools to the shell
+environment, making it possible for users to perform RAID configuration from 
+petitboot, before installing an operating system.
 
-This specification is for plugins to the Petitboot Bootloader environment.
-
-The petitboot bootloader is part of the OpenPower firmware stack.
-
-This document describes what plugin authors can expect, what is explicitly
-supported and what is explicitly *not* supported.
-
-Authors
--------
-Initial Specification Draft: Stewart Smith <stewart@linux.vnet.ibm.com>
-Reference implementation of Petitboot Plugin: Jeremy Kerr <jk@ozlabs.org>
-
-Availability
-------------
-The first op-build release to support petitboot plugins is v1.7 (released
-September 2015). Refer to individual firmware vendor's release notes to
-find minimal firmware versions for shipping machines.
-
-Prior versions of OPAL firmware do *not* support petitboot plugins of any
-type.
-
-Goal
-----
-
-To allow vendors to provide various userspace tools and utilities for
-execution within the petitboot environment.
-
-For example: configuration utilities for RAID cards.
-
-Petitboot plugins are not meant to solve all of the possible problems,
-sometimes providing a bootable image may be preferable to a petitboot
-plugin.
-
-Implementation
---------------
-See petitboot/utils/pb-plugin source for the reference implementation.
-
-File format
------------
-
-Petitboot plugins are a gzip compressed cpio archive ending in ".pb-plugin".
-
-Within this archive, there MUST exist a etc/preboot-plugins/pb-plugin.conf
-file (see pb-plugin.conf definition below).
-
-As of petitboot plugin ABI version 1, the etc/preboot-plugins/ directory
-is reserved and MUST NOT contain any files other than pb-plugin.conf
-
-The archive will be extracted and run in a chroot-like environment, so it
-is RECOMMENDED that plugins follow the Filesystem Hierarchy Standard, although
-this is not REQUIRED. The intention is to isolate the plugin from both other
-plugins and the petitboot environment itself.
-
-The following paths MAY exist but the petitboot environment MAY (and indeed,
-in the current implementation WILL) mount filesystems over them:
-- dev
-- sys
-- proc
-- var
-
-The petitboot environment WILL provide a full proc filesystem in /proc
-The petitboot environment WILL provide a full sysfs filesystem in /sys
-The petitboot environment WILL provide a full set of device nodes in /dev
-The petitboot environment WILL share /var outside of the plugin environment
-(possibly including other plugins' chroots).
-The petitboot environment WILL create the mountpoints if nedeed.
-The petitboot environment WILL create/replace the plugin's etc/resolv.conf
-
-See Plugin ABI section.
-See also: http://refspecs.linuxfoundation.org/fhs.shtml
-
-Petitboot plugin location
--------------------------
-The petitboot environment MAY support discovery of plugins. It will search
-ONLY in the root directory of accessible file systems.
-
-Petitboot plugins MAY be installed from other locations, possibly even over
+Plugins can be installed from storage devices (like a USB flash drive), or from
 the network.
 
-pb-plugin.conf contents
+Essentialy, a plugin is just an archive of files to be extracted into the
+petitboot filesystem, mostly for usage at the command-line. Plugins are not
+persisted once you leave the petitboot environment.
+
+The specification for petitboot plugins here:
+
+ https://github.com/open-power/docs/blob/master/opal/petitboot-plugin-spec.txt
+
+And the implementation:
+
+ https://github.com/open-power/petitboot/blob/master/utils/pb-plugin
+
+Using a petitboot plugin
+------------------------
+
+The 'pb-plugin' command at the petitboot shell is used to manage plugins
+in the currently-running environment.
+
+For network usage, installing done by:
+
+    pb-plugin install <URL>
+
+For removeable media, installing is a similar process:
+
+    pb-plugin install </path/to/FILE>
+
+To make the above easier, you can run:
+
+    pb-plugin scan
+
+\- to look for plugins that are present on attached storage, and print a list of
+those found.
+
+Here is an example of running a 'scan' with a plugin
+present on a local USB drive:
+
+    / # pb-plugin scan
+    Plugin found on sda1:
+    Sample co: Example petitboot plugin
+      (version 1.01)
+    
+    To run this plugin:
+      /usr/sbin/pb-plugin install /var/petitboot/mnt/dev/sda1/example.pb-plugin
+    
+Now that we know that there's a plugin present, we can install it as
+indicated:
+
+    / # pb-plugin install /var/petitboot/mnt/dev/sda1/example.pb-plugin 
+    File 'example.pb-plugin' has the following sha256 checksum:
+
+    e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+    Do you want to install this plugin? (y/N)
+    y
+    1023 blocks
+    Plugin installed
+    Sample co: Example petitboot plugin
+      (version 1.01)
+
+Once the plugin is installed, the executables defined by the plugin are
+available at the shell, like any other command.
+
+Constructing a new plugin
+-------------------------
+
+A plugin is pretty simple: it's just the files that need to be added to
+the petitboot environment, plus a bit of metadata. This is combined into
+a compressed CPIO archive, with the extension .pb-plugin
+
+The pb-plugin script can also be used as a helper to construct a plugin. First,
+download the script from
+
+ https://raw.githubusercontent.com/open-power/petitboot/master/utils/pb-plugin
+
+and run:
+
+    pb-plugin create <DIR>
+
+\- this will create a plugin out of the contents of `<DIR>`.
+
+This can be done from most Linux/UNIX installs, not just petitboot; the
+pb-plugin script is a standard shell script, and can be used outside of
+petitboot when you're constructing a plugin.
+
+If no metadata definition is present under DIR (specifically, at
+`<DIR>/etc/preboot-plugins/pb-plugin.conf`), then the script will prompt for
+details, and create one. This can be edited later, if necessary.
+
+The resulting .pb-plugin file can then be made available on the network
+(accessible to the POWER machines), or copied to the top-level directory of a
+USB/cdrom/etc device. Presence at the top level is not required, but does allow
+the `pb-plugin scan` function to find it.
+
+The binaries included in the plugin will need to be compatible with
+the petitboot environment. Generally, this either means that any necessary
+libraries are shipped in the plugin, or the binary is statically-linked.
+
+Pre-distribution check
 ----------------------
-This file tells petitboot about the plugin.
 
-Within the petitboot plugin, it is found at etc/preboot-plugins/pb-plugin.conf
+Before distributing a new plugin, you can perform some basic checks on a with:
 
-Within this file, there MUST exist the following key/value pairs with the format
-KEY=VALUE :
+    pb-plugin lint <FILE.pb-plugin>
 
-PLUGIN_ABI
-PLUGIN_ABI_MIN
-PLUGIN_VENDOR
-PLUGIN_VENDOR_ID
-PLUGIN_NAME
-PLUGIN_ID
-PLUGIN_VERSION
-PLUGIN_DATE
-PLUGIN_EXECUTABLES
+\- which will report on potential problems with the metadata.
 
-Values MAY be quoted. The pb-plugin.conf file is NOT executed shell and must
-not be treated as such.
+Low level details on plugin runtime behaviour
+---------------------------------------------
 
-Example:
-PLUGIN_ABI='1'
-PLUGIN_ABI_MIN='1'
-PLUGIN_VENDOR='OpenPower Foundation'
-PLUGIN_VENDOR_ID='OpenPower'
-PLUGIN_NAME='Hello World Petitboot Plugin Example 1'
-PLUGIN_ID='Hello World'
-PLUGIN_VERSION='1.0'
-PLUGIN_DATE='2015-09-16'
-PLUGIN_EXECUTABLES='/usr/bin/hello-world /usr/bin/other-binary'
+During installation, plugins are extracted into a new directory under `/tmp`.
+This ensures that the contents of the plugin do not conflict with files in the
+petitboot system.
 
-In the future, additional variables may be added, but these ones MUST ALWAYS
-exist. This allows any future incompatible change to gracefully fail, telling
-the user about the presence of a plugin that cannot be run.
+When a user invokes one of the plugins provided in the binary, that binary is
+executed in a "chroot" (an isolated filesystem structure) of that new directory.
+This means that binaries can use any other resources in their archive, and
+ensure that there are no conflicts with the rest of the petitboot environment
+(including other plugins).
 
-The following restrictions apply:
-- PLUGIN_ABI and PLUGIN_ABI_MIN must be numeric (0-9+)
-- PLUGIN_ID and PLUGIN_VENDOR_ID should only contain lowercase alphanumerics
-  and hyphens
-- PLUGIN_DATE *MUST* be in the format YYYY-MM-DD
-  The format MM/DD/YY is EXPLICITLY NOT SUPPORTED or encouraged. Anywhere. Ever.
+The caveat here is that the plugin cannot access resources outside of its own
+shipped files, such as runtime libraries. This is somewhat intentional, as
+the petitboot environment does not guarantee that those resources will remain
+consistent across different builds & versions of petitboot environments.
 
-The PLUGIN_NAME and PLUGIN_VENDOR variables MAY contain UTF-8 encoded
-characters, typically to allow plugins implemented in langauges other than
-English. However, there is no guarantee that users will be using a terminal
-emulator that can support non-ASCII characters. Other variables should only
-contain ASCII characters.
+So, if your plugin's binaries depend on any runtime libraries, or the dynamic
+linker, those resources must be included in the plugin too.
 
-PLUGIN_EXECUTABLES is a space-separated list of executables that are made
-available for the user to invoke. Each executable in PLUGIN_EXECUTABLES
-*SHOULD* have a unique filename (excluding the path). Since the petitboot
-environment creates a wrapper script to execute the plugin from the petitboot
-shell environment, installing two plugins with the same executable name WILL
-conflict, with whatever plugin was installed most recently winning.
+When a plugin is installed into petitboot, the pb-plugin script performs the
+following:
 
-It is thus RECOMMENDED that you name executables along the lines of
-'openpower-hello-world' rather than just 'hello-world' so as not to conflict
-with a possible 'acme-hello-world'.
+ - extracts the contents of the archive into a temporary directory
 
-Plugin ABI versioning
----------------------
+ - creates a wrapper script for each of the executables listed in the
+   `PLUGIN_EXECUTABLES` metadata. These wrapper scripts are added to
+   `/var/lib/pb-plugins/bin/<NAME>`, which is included in the default PATH.
 
-The Petitboot environment will support a petitboot plugin ABI version.
-Each petitboot plugin has a minimal ABI version it supports running.
+These wrapper scripts handle all of the chroot setup, so that it is transparent
+to the end user.
 
-If the petitboot plugin's ABI version is GREATER than the petitboot
-environment's, the plugin MUST NOT be run.
+See the petitboot plugin specification at
+https://github.com/open-power/docs/blob/master/opal/petitboot-plugin-spec.txt
+for full implementation requirements.
 
-A plugin is OK to run if:
-1. the plugin's ABI matches the petitboot environment's ABI, or
-2. the plugin's minimum ABI is lower than or equal to the petitboot
-   enviornement's ABI
-
-Plugin ABI
+Need help?
 ----------
-The Petitboot environment provides the following ABI to plugins:
-- Linux kernel ppc64el ABI
-  - with the expectation that executables fail gracefully if certain
-    kernel features are not available.
-  - depending on optional kernel features is NOT RECOMMENDED.
-    For the large part: be sensible. You can expect syscalls as of
-    linux 4.2 to exist.
-    - Some plugins may REQUIRE certain functionality to be enabled in
-      the petitboot kernel (for example: a specific RAID driver).
-      It is encouraged to fail gracefully in the absence of this
-      driver with an easy to understand error message for the user.
 
-It EXPLICITLY DOES NOT support kernel modules. You MUST NOT include
-kernel modules in your plugin. If you require kernel module support,
-ship instead a bootable disk rather than a petitboot plugin.
-
-As each plugin executes in its own chroot environment, binaries must
-either be statically linked or MUST include ALL dependencies (for example:
-dynamic linker, libc, ncurses)
-
-Plugin executables execute as root in the plugin's chroot environment. The
-plugin chroot environment is temporary and IS NOT persistent across reboots.
-This is implemented in the reference implementation by extracting the
-plugin into a ram disk.
-
-The var/ mountpoint inside a plugin chroot environment is a bind mount
-of the petitboot environment /var. Be sensible with logging within your
-petitboot plugin: don't overwrite petitboot logs, log to a file name unique
-to your plugin.
-
-While more than just var/log is exposed to the plugin, it is explictily
-NOT SUPPORTED to use the var/ bind mount for anything BUT logging.
-
-It is possible that in a future release, the implementation may change so
-that the plugin CANNOT access anything but its own logs in var/ but that
-the petitboot environment CAN access the logs of the plugin.
+If you need help constructing a plugin, contact the OPAL developers at
+skiboot@lists.ozlabs.org.


### PR DESCRIPTION
This change adds a document for usage and construction of petitboot
plugins, to supplement the spec that's already there.

Since the spec uses the petitboot-plugins.txt name, we move it to make
way for the document.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/docs/18)
<!-- Reviewable:end -->
