### PR TITLE
Add initial documents describing OpenPOWER SELs & sensors

### DIFF
--- a/management/sels.txt
+++ b/management/sels.txt
@@ -1,0 +1,18 @@
+System Event Logs (SELs) on OpenPOWER platforms
+===============================================
+
+OpenPOWER BMCs will record standard IPMI SEL logs, but will typically vary by
+BMC implementation. For general system fault monitoring, SEL events logged
+against the Fault sensors (see the sensors.txt document) will be raised to
+indicate FRU-specific faults.
+
+In addition to these standard SEL events, host firmware may generate the
+following types of SELs:
+
+ * SEL type 0xdf: flattened PEL
+ * SEL type 0xde: symbolic fru/isolation procedure
+
+These events are also reflected in an eSEL record, which contains extended debug
+data for fault analysis
+
+TODO: eSEL interpretation

--- a/management/sensors.txt
+++ b/management/sensors.txt
@@ -1,0 +1,72 @@
+Sensors on OpenPOWER platforms
+==============================
+
+There are a number of sensors defined for OpenPOWER machines - some controlled
+by the POWER host, and some controlled by the management controller.
+
+ * "Func" (functional) sensors
+    Sensor type: discrete, specific type depends on component
+    Set by: hostboot
+
+    These represent whether a component is functional, and are set at boot-time
+    by hostboot firmware.
+
+    These are IPMI assertion sensors, complying with the IPMI-defined assertion
+    states appropriate to the sensor type.
+
+ * BIOS Golden side & BMC Golden side
+   Sensor type: OEM discrete (0xc3)
+   Set by: BMC
+
+   Bit 0 (the least-significant bit) indicates golden side boot. 0 = primary
+   side, 1 = working side.
+
+ * Boot count
+   Sensor type: OEM discrete (0xc3)
+   Set by: BMC, OPAL
+
+   The assertion bits (read as a uint8) indicate the boot count value. The BMC
+   uses this to detect when the system has failed sucessive boots, and should be
+   started in golden-side mode.
+
+ * "Fault" sensors
+   Sensor type: OEM discrete (0xc7)
+   Set by: hostboot
+
+   The least-significant assertion bit indicates a fault.
+ 
+ * Firmware boot progress
+   Sensor type: discrete, System Firmware Progress (0x0f)
+
+   Assertion type. During boot, hostboot and OPAL will update this sensor to one
+   of the IPMI-defined progress codes.
+
+ * Turbo allowed
+   Sensor type: OEM discrete (0xcb)
+   Set by: BMC
+
+   Single-state digital sensor that indicates whether the on-chip controllers
+   will allow the host processors to enter turbo mode.
+
+ * System Event
+   Sensor type: discrete, System Event (0x61)
+   Set by: hostboot
+
+   Will assert an IPMI-specified system failure state.
+
+TODO
+----
+
+ * APSS sensor
+ * Power/current sensor(s)
+ * Quick Power drop sensor
+
+Further details
+---------------
+
+There are some further details of IPMI sensor interactions here:
+
+ * OPAL documentation on BMC interactions:
+   https://github.com/open-power/skiboot/blob/master/doc/bmc.txt
+
+


### PR DESCRIPTION
This change introduces a couple of new documents to the management/ directory, with details on the SEL and sensors that are implemented on most OpenPOWER machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/docs/19)
<!-- Reviewable:end -->
